### PR TITLE
Don't panic on parent connectivity problems

### DIFF
--- a/parent.go
+++ b/parent.go
@@ -55,7 +55,7 @@ func newParent(env *env) (*parent, map[fileName]*file, error) {
 
 		n, err := io.Copy(ioutil.Discard, rd)
 		if n != 0 {
-			exited <- errors.New("unexpected data tail from parent processdiscarded")
+			exited <- errors.New("unexpected data from parent process")
 		}
 		for err != nil {
 			// permantent lock; see issue #1

--- a/process_test.go
+++ b/process_test.go
@@ -78,7 +78,7 @@ func (tp *testProcess) recvSignal(err error) os.Signal {
 	return sig
 }
 
-func (tp *testProcess) notify() (map[fileName]*file, <-chan struct{}, error) {
+func (tp *testProcess) notify() (map[fileName]*file, <-chan error, error) {
 	parent, files, err := newParent(&tp.env)
 	if err != nil {
 		return nil, nil, err

--- a/upgrader.go
+++ b/upgrader.go
@@ -158,8 +158,13 @@ func (u *Upgrader) Upgrade() error {
 	}
 
 	if u.parent != nil {
+		// verify clean exit
 		select {
-		case <-u.parent.exited:
+		case err := <-u.parent.exited:
+			if err != nil {
+				return err
+			}
+
 		default:
 			return errors.New("parent hasn't exited")
 		}

--- a/upgrader_test.go
+++ b/upgrader_test.go
@@ -258,7 +258,10 @@ func TestUpgraderReady(t *testing.T) {
 	u.exitFd.file.Close()
 
 	select {
-	case <-exited:
+	case err := <-exited:
+		if err != nil {
+			t.Error("exit error", err)
+		}
 	case <-time.After(time.Second):
 		t.Error("Child wasn't notified of parent exiting")
 	}


### PR DESCRIPTION
After receiving the file name mapping from the parent process, the connectivity is read until EOF in a separate routine. Errors there should not lead to a panic as they might even occur after a successful handover, at least in theory.

I'd recommend a proper handshake with forward compatibility in mind.