### PR TITLE
Fix upgrade error to use format string

### DIFF
--- a/upgrader.go
+++ b/upgrader.go
@@ -193,7 +193,7 @@ func (u *Upgrader) Upgrade() error {
 		if err == nil {
 			return errors.Errorf("child %s exited", child)
 		}
-		return errors.Wrap(err, "child %s exited")
+		return errors.Wrapf(err, "child %s exited", child)
 
 	case <-u.stopC:
 		child.Kill()


### PR DESCRIPTION
One of the child exited upgrade errors used a format string, but was
using errors.Wrap instead of errors.Wrapf.