### PR TITLE
Use os.File.SyscallConn from Go 1.12

### DIFF
--- a/dup_file.go
+++ b/dup_file.go
@@ -1,0 +1,12 @@
+// +build go1.12
+
+package tableflip
+
+import (
+	"os"
+)
+
+func dupFile(fh *os.File, name fileName) (*file, error) {
+	// os.File implements syscall.Conn from go 1.12
+	return dupConn(fh, name)
+}

--- a/dup_file_legacy.go
+++ b/dup_file_legacy.go
@@ -1,0 +1,11 @@
+// +build !go1.12
+
+package tableflip
+
+import (
+	"os"
+)
+
+func dupFile(fh *os.File, name fileName) (*file, error) {
+	return dupFd(fh.Fd(), name)
+}

--- a/fds.go
+++ b/fds.go
@@ -228,11 +228,12 @@ func (f *Fds) File(name string) (*os.File, error) {
 
 // AddFile adds a file.
 //
-// As of Go 1.11, file will be in blocking mode
+// Until Go 1.12, file will be in blocking mode
 // after this call.
 func (f *Fds) AddFile(name string, file *os.File) error {
 	key := fileName{fdKind, name}
-	dup, err := dupFd(file.Fd(), key)
+
+	dup, err := dupFile(file, key)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adding an os.File to Fds currently causes the underlying file to
be put into blocking mode. Use a new API to avoid this.