### PR TITLE
add WaitForParentExit to Upgrader

### DIFF
--- a/upgrader.go
+++ b/upgrader.go
@@ -236,6 +236,10 @@ func (u *Upgrader) WaitForParentExit(ctx context.Context) error {
 		<-u.upgradeSem
 	}()
 
+	if u.parentErr != nil {
+		return u.parentErr
+	}
+
 	select {
 	case err := <-u.parent.exited:
 		return err

--- a/upgrader.go
+++ b/upgrader.go
@@ -242,6 +242,9 @@ func (u *Upgrader) WaitForParentExit(ctx context.Context) error {
 
 	select {
 	case err := <-u.parent.exited:
+		if err != nil {
+			u.parentErr = err
+		}
 		return err
 	case <-ctx.Done():
 		return ctx.Err()


### PR DESCRIPTION
So that the child process can do something when it's sure that parent has exited.