### PR TITLE
Refactor the upgrader into a goroutine

### DIFF
--- a/child_test.go
+++ b/child_test.go
@@ -15,7 +15,7 @@ func TestChildExit(t *testing.T) {
 
 	proc := <-procs
 	proc.exit(nil)
-	if err := <-child.exitedC; err != nil {
+	if err := <-child.result; err != nil {
 		t.Error("Wait returns non-nil error:", err)
 	}
 }
@@ -48,10 +48,11 @@ func TestChildNotReady(t *testing.T) {
 
 	proc := <-procs
 	proc.exit(nil)
-	<-child.exitedC
+	<-child.result
+	<-child.exited
 
 	select {
-	case <-child.readyC:
+	case <-child.ready:
 		t.Error("Child signals readiness without pipe being closed")
 	default:
 	}
@@ -69,7 +70,7 @@ func TestChildReady(t *testing.T) {
 	if _, _, err := proc.notify(); err != nil {
 		t.Fatal("Can't notify:", err)
 	}
-	<-child.readyC
+	<-child.ready
 	proc.exit(nil)
 }
 

--- a/parent_test.go
+++ b/parent_test.go
@@ -17,7 +17,7 @@ func TestParentExit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	readyFile := <-child.readyC
+	readyFile := <-child.ready
 	if _, err = readyFile.Write([]byte{1}); err != nil {
 		t.Fatal("Can't inject garbage from parent")
 	}

--- a/process_test.go
+++ b/process_test.go
@@ -84,5 +84,5 @@ func (tp *testProcess) notify() (map[fileName]*file, <-chan error, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	return files, parent.exited, parent.sendReady()
+	return files, parent.result, parent.sendReady()
 }


### PR DESCRIPTION
The upgrader has fairly complex logic and locking behaviour. The Stop() method
is more involved than it should be, since we need to clean up if no upgrade
happened.

Moving the code into a goroutine makes the flow and invariants easier to
understand.

There is one semantic change: Upgrade() does not return an error if the parent
unexpectedly writes to the shutdown pipe. The likelihood of this happening
is low, and it's not clear how severe that problem would be. By not rejecting
upgrade requests we allow users to fix such problems without having to do
a full restart.