### PR TITLE
Allow checking if Upgrader has a parent

### DIFF
--- a/upgrader.go
+++ b/upgrader.go
@@ -154,6 +154,11 @@ func (u *Upgrader) WaitForParent(ctx context.Context) error {
 	return err
 }
 
+// HasParent checks if the current process is an upgrade or the first invocation.
+func (u *Upgrader) HasParent() bool {
+	return u.parent != nil
+}
+
 // Upgrade triggers an upgrade.
 func (u *Upgrader) Upgrade() error {
 	response := make(chan error, 1)


### PR DESCRIPTION
There are situations in which is useful to detect the first invocation,
i.e. you may want to cleanup dangling unix sockets, but not during an
upgrade.

Closes #23 