### PR TITLE
Pidfile: Use work directory if no path given

### DIFF
--- a/upgrader.go
+++ b/upgrader.go
@@ -262,6 +262,20 @@ type neverCloseThisFile struct {
 
 func writePIDFile(path string) error {
 	dir, file := filepath.Split(path)
+
+	// if dir is empty, the user properly specified just the name
+	// of the pid file expecting it to be created in the current work directory
+	if dir == "" {
+		var err error
+		dir, err = os.Getwd()
+		if err != nil {
+			// if we could not determine current working directory
+			// continue with empty dir and let ioutil.TempFile choose
+			// a default
+			dir = ""
+		}
+	}
+
 	fh, err := ioutil.TempFile(dir, file)
 	if err != nil {
 		return err

--- a/upgrader_test.go
+++ b/upgrader_test.go
@@ -378,6 +378,35 @@ func TestReadyWritesPIDFile(t *testing.T) {
 	}
 }
 
+func TestWritePidFileWithoutPath(t *testing.T) {
+	pidFile := "tableflip-test.pid"
+
+	err := writePIDFile(pidFile)
+	if err != nil {
+		t.Fatal("Could not write pidfile:", err)
+	}
+	defer os.Remove(pidFile)
+
+	// lets see if we are able to read the file back
+	fh, err := os.Open(pidFile)
+	if err != nil {
+		t.Fatal("PID file doesn't exist:", err)
+	}
+	defer fh.Close()
+
+	// just to be sure: check the pid for correctness
+	// if something failed at a previous run we could be reading
+	// a bogus pidfile
+	var pid int
+	if _, err := fmt.Fscan(fh, &pid); err != nil {
+		t.Fatal("Can't read PID:", err)
+	}
+
+	if pid != os.Getpid() {
+		t.Error("PID doesn't match")
+	}
+}
+
 func BenchmarkUpgrade(b *testing.B) {
 	for _, n := range []int{4, 400, 4000} {
 		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {


### PR DESCRIPTION
Hello

When specifying just a filename e.g. `app.pid` as PIDFile option (expecting it to appear in the current working directory) - the previous code created a tmp file in `/tmp` and then tried to `os.Rename` it back to the current work directory - This results in `invalid cross-device link` errors from `os.Rename` if `/tmp` is on another mount point 

This is a proposal to fix the issue, by using the current work directory for the tmp file if no path was given :)