### PR TITLE
Embed Fds struct in Upgrader

### DIFF
--- a/upgrader.go
+++ b/upgrader.go
@@ -27,6 +27,8 @@ type Options struct {
 
 // Upgrader handles zero downtime upgrades and passing files between processes.
 type Upgrader struct {
+	*Fds
+
 	*env
 	opts      Options
 	parent    *parent
@@ -38,8 +40,6 @@ type Upgrader struct {
 	upgradeC  chan chan<- error
 	exitC     chan struct{}
 	exitFd    chan neverCloseThisFile
-
-	Fds *Fds
 }
 
 var (


### PR DESCRIPTION
Fds is a member of Upgrader, which makes it hard to stub out Upgrader
with an interface for testing. Embed Fds in Upgrader to fix this.
Users can then write code like

    ln, err := upg.Listen("foo", "bar")

and use a single interface. Existing code will continue to work.