### PR TITLE
Make tests pass on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ go:
   - "1.10.x"
   - "1.11.x"
   - master
+
+os:
+  - linux
+  - osx

--- a/fds.go
+++ b/fds.go
@@ -3,6 +3,7 @@ package tableflip
 import (
 	"net"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -278,7 +279,7 @@ func (f *Fds) closeInherited() {
 }
 
 func unlinkUnixSocket(path string) error {
-	if strings.HasPrefix(path, "@") {
+	if runtime.GOOS == "linux" && strings.HasPrefix(path, "@") {
 		// Don't unlink sockets using the abstract namespace.
 		return nil
 	}


### PR DESCRIPTION
Neither empty socket paths nor the abstract namespace are supported by
macOS.