### PR TITLE
Add go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/cloudflare/tableflip
+
+go 1.12


### PR DESCRIPTION
This enables support for go modules, which will be enabled by default starting from Go 1.13.
After this, please create a github release in a semantic format. (v0.0.0)