### PR TITLE
Support binding to the same address with SO_REUSEPORT

### DIFF
--- a/fds_test.go
+++ b/fds_test.go
@@ -1,6 +1,7 @@
 package tableflip
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -29,6 +30,25 @@ func TestFdsListen(t *testing.T) {
 			t.Fatal("Missing listener", addr)
 		}
 		ln.Close()
+	}
+}
+
+func TestFdsListen_ReusePort(t *testing.T) {
+	fds := newFds(nil)
+
+	ln, err := fds.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = fds.Listen("tcp", fmt.Sprintf(":%s", port))
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/cloudflare/tableflip
 
 go 1.12
+
+require (
+	github.com/pkg/errors v0.9.1
+	golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d
+)


### PR DESCRIPTION
This allows a second listener to bind to the same address. fixes: https://github.com/cloudflare/tableflip/issues/46