### PR TITLE
ensure that inherited files are nonblocking

### DIFF
--- a/child.go
+++ b/child.go
@@ -41,9 +41,14 @@ func startChild(env *env, passedFiles map[fileName]*file) (*child, error) {
 	}
 
 	// Copy environment and append the notification env vars
-	environ := append([]string(nil), env.environ()...)
-	environ = append(environ,
-		fmt.Sprintf("%s=yes", sentinelEnvVar))
+	sentinel := fmt.Sprintf("%s=yes", sentinelEnvVar)
+	var environ []string
+	for _, val := range env.environ() {
+		if val != sentinel {
+			environ = append(environ, val)
+		}
+	}
+	environ = append(environ, sentinel)
 
 	proc, err := env.newProc(os.Args[0], os.Args[1:], fds, environ)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudflare/tableflip
 
-go 1.13
+go 1.14

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/cloudflare/tableflip
 
 go 1.14
+
+require golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/process.go
+++ b/process.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
+	"syscall"
 )
 
 var initialWD, _ = os.Getwd()
@@ -15,33 +17,66 @@ type process interface {
 }
 
 type osProcess struct {
-	cmd *exec.Cmd
+	*os.Process
+	finished bool
 }
 
-func newOSProcess(executable string, args []string, files []*os.File, env []string) (process, error) {
-	cmd := exec.Command(executable, args...)
-	cmd.Dir = initialWD
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.ExtraFiles = files
-	cmd.Env = env
-
-	if err := cmd.Start(); err != nil {
+func newOSProcess(executable string, args []string, extraFiles []*os.File, env []string) (process, error) {
+	executable, err := exec.LookPath(executable)
+	if err != nil {
 		return nil, err
 	}
 
-	return &osProcess{cmd}, nil
-}
+	files := append([]*os.File{os.Stdin, os.Stdout, os.Stderr}, extraFiles...)
+	fds := make([]uintptr, 0, len(files))
+	for _, file := range files {
+		fd, err := sysConnFd(file)
+		if err != nil {
+			return nil, err
+		}
+		fds = append(fds, fd)
+	}
 
-func (osp *osProcess) Signal(sig os.Signal) error {
-	return osp.cmd.Process.Signal(sig)
+	attr := &syscall.ProcAttr{
+		Dir:   initialWD,
+		Env:   env,
+		Files: fds,
+	}
+
+	pid, _, err := syscall.StartProcess(executable, args, attr)
+	if err != nil {
+		return nil, fmt.Errorf("fork/exec: %s", err)
+	}
+
+	// Ensure that fds stay valid until after StartProcess finishes.
+	runtime.KeepAlive(files)
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return nil, fmt.Errorf("find pid %d: %s", pid, err)
+	}
+
+	return &osProcess{Process: proc}, nil
 }
 
 func (osp *osProcess) Wait() error {
-	return osp.cmd.Wait()
+	if osp.finished {
+		return fmt.Errorf("already waited")
+	}
+	osp.finished = true
+
+	state, err := osp.Process.Wait()
+	if err != nil {
+		return err
+	}
+
+	if !state.Success() {
+		return &exec.ExitError{ProcessState: state}
+	}
+
+	return nil
 }
 
 func (osp *osProcess) String() string {
-	return fmt.Sprintf("pid=%d", osp.cmd.Process.Pid)
+	return fmt.Sprintf("pid=%d", osp.Pid)
 }


### PR DESCRIPTION

The Go runtime has annoying behaviour around setting and clearing
O_NONBLOCK: exec.Cmd.Start() ends up calling os.File.Fd() for any
file in exec.Cmd.ExtraFiles. os.File.Fd() disables both the use
of the runtime poller for the file and clears O_NONBLOCK from
the underlying open file descriptor.

Disabling the runtime poller is bad because it makes operating on
those files less efficient. We can work around this by always
working on duplicate os.File. Since the library itself never
reads or writes from the files it doesn't matter whether the
runtime poller is enabled or not.

Clearing O_NONBLOCK is much more annoying, since it's shared by
all fds pointing to the same open file descriptor. This can lead
to hard to diagnose hangs in code invoking syscalls on the file
descriptors, like read or accept. Even more troubling, File.Close
doesn't interrupt these syscalls anymore. Depending on how the
application is structured this can lead to indefinite hangs.

Fix this by writing a simplified wrapper around syscall.StartProcess.
It turns out that we don't need most features of exec.Cmd anyways.

A full restart is needed to make files non-blocking again in
deployed processes.