### PR TITLE
fix incorrect arguments when starting a child

### DIFF
--- a/process.go
+++ b/process.go
@@ -43,6 +43,7 @@ func newOSProcess(executable string, args []string, extraFiles []*os.File, env [
 		Files: fds,
 	}
 
+	args = append([]string{executable}, args...)
 	pid, _, err := syscall.StartProcess(executable, args, attr)
 	if err != nil {
 		return nil, fmt.Errorf("fork/exec: %s", err)

--- a/process_test.go
+++ b/process_test.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func TestNewOSProcess(t *testing.T) {
+func TestFilesAreNonblocking(t *testing.T) {
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
@@ -43,6 +43,19 @@ func TestNewOSProcess(t *testing.T) {
 
 	if !isNonblock(t, r) {
 		t.Fatal("Read pipe is blocking after newOSProcess")
+	}
+}
+
+func TestArgumentsArePassedCorrectly(t *testing.T) {
+	proc, err := newOSProcess("printf", []string{""}, nil, nil)
+	if err != nil {
+		t.Fatal("Can't execute printf:", err)
+	}
+
+	// If the argument handling is wrong we'll call printf without any arguments.
+	// In that case printf exits non-zero.
+	if err = proc.Wait(); err != nil {
+		t.Fatal("printf exited non-zero:", err)
 	}
 }
 


### PR DESCRIPTION
The previous commit introduced a bug in how arguments are passed to
children. We need to make argv[0] the name of the binary, otherwise
the first argument we pass becomes argv[0].