### PR TITLE
loop reload failed

### DIFF
--- a/child.go
+++ b/child.go
@@ -50,7 +50,7 @@ func startChild(env *env, passedFiles map[fileName]*file) (*child, error) {
 	}
 	environ = append(environ, sentinel)
 
-	proc, err := env.newProc(os.Args[0], os.Args[1:], fds, environ)
+	proc, err := env.newProc(os.Args[0], os.Args[:], fds, environ)
 	if err != nil {
 		readyR.Close()
 		readyW.Close()

--- a/process.go
+++ b/process.go
@@ -42,7 +42,6 @@ func newOSProcess(executable string, args []string, files []*os.File, env []stri
 		Files: fds,
 	}
 
-	args = append([]string{executable}, args...)
 	pid, _, err := syscall.StartProcess(executable, args, attr)
 	if err != nil {
 		return nil, fmt.Errorf("fork/exec: %s", err)


### PR DESCRIPTION
loop always miss first args

1 start:
`procname -c xxx.conf`

2 reload:
`kill -HUP parent pid`

3 look proc:
`ps aux|grep ${procname}`  or
lsof -p `parent pid`

child args is 
`-c xxx.conf` it's wrong

4 continue reload:
`kill -HUP child pid`

reload failed
