### PR TITLE
unset instance from global env once it's stopped

### DIFF
--- a/upgrader.go
+++ b/upgrader.go
@@ -147,6 +147,12 @@ func (u *Upgrader) Stop() {
 		// Interrupt any running Upgrade(), and
 		// prevent new upgrade from happening.
 		close(u.stopC)
+
+		stdEnvMu.Lock()
+		defer stdEnvMu.Unlock()
+
+		// Remove from global env so that new instance can be created
+		stdEnvUpgrader = nil
 	})
 }
 


### PR DESCRIPTION
This allows new instance to be created when an old instance has stopped. This is
useful especially in test cases.