### PR TITLE
Fix gofmt issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Check lint
       # gofmt doesn't report any changes
-      run: test -z $(gofmt -l ./ | tee /dev/stderr)
+      run: test -z "$(gofmt -l ./ | tee /dev/stderr)"
 
     - name: Run tests
       run: go test ./...

--- a/dup_fd.go
+++ b/dup_fd.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package tableflip

--- a/env_syscalls.go
+++ b/env_syscalls.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package tableflip


### PR DESCRIPTION
The old build constraints now generate `gofmt` failures, also the workflow check for code format fails with the wrong error message.