### PR TITLE
Switch to x/sys/unix where possible

### DIFF
--- a/dup_fd.go
+++ b/dup_fd.go
@@ -5,14 +5,15 @@ package tableflip
 
 import (
 	"fmt"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func dupFd(fd uintptr, name fileName) (*file, error) {
-	dupfd, _, errno := syscall.Syscall(syscall.SYS_FCNTL, fd, syscall.F_DUPFD_CLOEXEC, 0)
-	if errno != 0 {
-		return nil, fmt.Errorf("can't dup fd using fcntl: %s", errno)
+	dupfd, err := unix.FcntlInt(fd, unix.F_DUPFD_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("can't dup fd using fcntl: %s", err)
 	}
 
-	return newFile(dupfd, name), nil
+	return newFile(uintptr(dupfd), name), nil
 }

--- a/env_syscalls.go
+++ b/env_syscalls.go
@@ -5,7 +5,8 @@ package tableflip
 
 import (
 	"os"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 var stdEnv = &env{
@@ -13,5 +14,5 @@ var stdEnv = &env{
 	newFile:     os.NewFile,
 	environ:     os.Environ,
 	getenv:      os.Getenv,
-	closeOnExec: syscall.CloseOnExec,
+	closeOnExec: unix.CloseOnExec,
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/cloudflare/tableflip
 
 go 1.14
 
-require golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
+require golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

x/sys/unix should be preferred to syscall where equivalent calls exist, and we can replace a manual syscall shim with the tidy unix.FcntlInt API.