### PR TITLE
Kerolasa/init wd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.15'
+        go-version: '^1.24'
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.15'
+        go-version: '^1.24'
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/doc.go
+++ b/doc.go
@@ -13,18 +13,18 @@
 // To use this library with systemd you need to use the PIDFile option in the service
 // file.
 //
-//    [Unit]
-//    Description=Service using tableflip
+//	[Unit]
+//	Description=Service using tableflip
 //
-//    [Service]
-//    ExecStart=/path/to/binary -some-flag /path/to/pid-file
-//    ExecReload=/bin/kill -HUP $MAINPID
-//    PIDFile=/path/to/pid-file
+//	[Service]
+//	ExecStart=/path/to/binary -some-flag /path/to/pid-file
+//	ExecReload=/bin/kill -HUP $MAINPID
+//	PIDFile=/path/to/pid-file
 //
 // Then pass /path/to/pid-file to New. You can use systemd-run to
 // test your implementation:
 //
-//    systemd-run --user -p PIDFile=/path/to/pid-file /path/to/binary
+//	systemd-run --user -p PIDFile=/path/to/pid-file /path/to/binary
 //
 // systemd-run will print a unit name, which you can use with systemctl to
 // inspect the service.
@@ -44,5 +44,4 @@
 // which may be necessary in certain development circumstances, but it will not
 // provide zero downtime upgrades when running on Windows. See the `testing`
 // package for an example of how to use it.
-//
 package tableflip

--- a/fds_test.go
+++ b/fds_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"testing"
 )
 
@@ -443,6 +444,11 @@ func TestFdsFiles(t *testing.T) {
 	if len(files) != len(testcases) {
 		t.Fatalf("Expected %d files, got %d", len(testcases), len(files))
 	}
+
+	// Sort files by name to ensure deterministic order
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Name() < files[j].Name()
+	})
 
 	for i, ff := range files {
 		tc := testcases[i]

--- a/fds_test.go
+++ b/fds_test.go
@@ -2,7 +2,6 @@ package tableflip
 
 import (
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -58,7 +57,7 @@ func TestFdsAddPacketConn(t *testing.T) {
 func tempSocket(t *testing.T) (string, func()) {
 	t.Helper()
 
-	temp, err := ioutil.TempDir("", "tableflip")
+	temp, err := os.MkdirTemp("", "tableflip")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudflare/tableflip
 
-go 1.14
+go 1.25.0
 
-require golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
+require golang.org/x/sys v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/parent.go
+++ b/parent.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -54,7 +53,7 @@ func newParent(env *env) (*parent, map[fileName]*file, error) {
 	go func() {
 		defer rd.Close()
 
-		n, err := io.Copy(ioutil.Discard, rd)
+		n, err := io.Copy(io.Discard, rd)
 		if n != 0 {
 			err = errors.New("unexpected data from parent process")
 		} else if err != nil {

--- a/process.go
+++ b/process.go
@@ -8,8 +8,6 @@ import (
 	"syscall"
 )
 
-var initialWD, _ = os.Getwd()
-
 type process interface {
 	fmt.Stringer
 	Signal(sig os.Signal) error
@@ -24,7 +22,7 @@ type osProcess struct {
 func newOSProcess(executable string, args []string, files []*os.File, env []string) (process, error) {
 	executable, err := exec.LookPath(executable)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("exec failed: %s", err)
 	}
 
 	fds := make([]uintptr, 0, len(files))
@@ -36,8 +34,13 @@ func newOSProcess(executable string, args []string, files []*os.File, env []stri
 		fds = append(fds, fd)
 	}
 
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("get current working directory failed: %s", err)
+	}
+
 	attr := &syscall.ProcAttr{
-		Dir:   initialWD,
+		Dir:   wd,
 		Env:   env,
 		Files: fds,
 	}

--- a/upgrader.go
+++ b/upgrader.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -298,7 +297,7 @@ func writePIDFile(path string) error {
 		return errors.New("empty initial working directory")
 	}
 
-	fh, err := ioutil.TempFile(dir, file)
+	fh, err := os.CreateTemp(dir, file)
 	if err != nil {
 		return err
 	}

--- a/upgrader.go
+++ b/upgrader.go
@@ -75,10 +75,6 @@ func New(opts Options) (upg *Upgrader, err error) {
 }
 
 func newUpgrader(env *env, opts Options) (*Upgrader, error) {
-	if initialWD == "" {
-		return nil, errors.New("couldn't determine initial working directory")
-	}
-
 	parent, files, err := newParent(env)
 	if err != nil {
 		return nil, err
@@ -290,16 +286,20 @@ func writePIDFile(path string) error {
 	// if dir is empty, the user probably specified just the name
 	// of the pid file expecting it to be created in the current work directory
 	if dir == "" {
-		dir = initialWD
+		wd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed get directory for pid file: %s", err)
+		}
+		dir = wd
 	}
 
 	if dir == "" {
-		return errors.New("empty initial working directory")
+		return errors.New("directory for pid file is empty")
 	}
 
 	fh, err := os.CreateTemp(dir, file)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create temporary pid file: %s", err)
 	}
 	defer fh.Close()
 	// Remove temporary PID file if something fails
@@ -307,10 +307,15 @@ func writePIDFile(path string) error {
 
 	_, err = fh.WriteString(strconv.Itoa(os.Getpid()))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to write pid file: %s", err)
 	}
 
-	return os.Rename(fh.Name(), path)
+	err = os.Rename(fh.Name(), path)
+	if err != nil {
+		return fmt.Errorf("failed to overwrite pid file: %s", err)
+	}
+
+	return nil
 }
 
 // Check if this is a supported OS.

--- a/upgrader_test.go
+++ b/upgrader_test.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"syscall"
 	"testing"
@@ -225,7 +225,7 @@ func TestUpgraderOnOS(t *testing.T) {
 	}
 
 	for i, name := range names {
-		nameBytes, err := ioutil.ReadAll(readers[i])
+		nameBytes, err := io.ReadAll(readers[i])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -441,13 +441,13 @@ func TestUpgraderShutdownCancelsUpgrade(t *testing.T) {
 func TestReadyWritesPIDFile(t *testing.T) {
 	t.Parallel()
 
-	dir, err := ioutil.TempDir("", "tableflip")
+	dir, err := os.MkdirTemp("", "tableflip")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
 
-	file := dir + "/pid"
+	file := filepath.Join(dir, "pid")
 	u := newTestUpgrader(Options{
 		PIDFile: file,
 	})


### PR DESCRIPTION
* chore: fix gofmt test failure
    
    The build failed with following message.
    
        Run test -z "$(gofmt -l ./ | tee /dev/stderr)"
        doc.go
        Error: Process completed with exit code 1.F
    
    Signed-off-by: Sami Kerola <kerolasa@cloudflare.com>

* DNS-12599: avoid failing upgrade due to initWD being empty
    
    When an initial working directory fails to populate upgrades will fail even
    when user supplied pid file is defined.  This change fixes the issue.
    
    Also add more information to error messages as a consequence of pull review.
    
    Reviewed-by: Christian Elmerot <christian@elmerot.se>
    Reference: https://github.com/cloudflare/tableflip/pull/85#discussion_r2710433050
    Signed-off-by: Sami Kerola <kerolasa@cloudflare.com>

* chore: do not use deprecated ioutls package
    
    Reference: https://pkg.go.dev/io/ioutil
    Signed-off-by: Sami Kerola <kerolasa@cloudflare.com>

* chore: vendor update 2026-01-13
    
    Signed-off-by: Sami Kerola <kerolasa@cloudflare.com>
